### PR TITLE
Proper versioning of signature verification instructions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6082,9 +6082,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/src/lib/calver.ts
+++ b/src/lib/calver.ts
@@ -1,0 +1,36 @@
+interface Range {
+  min: string;
+  max: string | null; // null means "no upper bound"
+}
+
+export interface Rule {
+  range: Range;
+  version: string;
+}
+
+function parse(ver: string): [number, number, number] {
+  const parts = ver.split('.').map(Number);
+  return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+}
+
+function compare(a: string, b: string): number {
+  const [ay, am, ap] = parse(a);
+  const [by, bm, bp] = parse(b);
+
+  if (ay !== by) return ay - by;
+  if (am !== bm) return am - bm;
+  return ap - bp;
+}
+
+function isInRange(version: string, min: string, max: string | null): boolean {
+  const aboveMin = compare(version, min) >= 0;
+  const belowMax = max === null || compare(version, max) <= 0;
+  return aboveMin && belowMax;
+}
+
+export function getDocsVersion(rules: Rule[], version: string): string | null {
+  const rule = rules.find(({ range }) =>
+    isInRange(version, range.min, range.max)
+  );
+  return rule?.version ?? null;
+}

--- a/src/pages/[version]/index.astro
+++ b/src/pages/[version]/index.astro
@@ -2,6 +2,8 @@
 import Files from "../../layouts/Files.astro";
 import { getGhafReleases, getArtifactsInRelease } from "../../lib/artifacts";
 import { S3_BUCKET, S3_ENDPOINT, S3_REGION } from "../../lib/constants";
+import { getDocsVersion } from "../../lib/calver";
+import type { Rule } from "../../lib/calver";
 
 export async function getStaticPaths() {
   const releases = await getGhafReleases();
@@ -10,11 +12,25 @@ export async function getStaticPaths() {
   }));
 }
 
+const docsRules: Rule[] = [
+  {
+    range: { min: "23.09", max: "24.06" },
+    version: "v1",
+  },
+  {
+    range: { min: "24.09", max: "24.09.2" },
+    version: "v2",
+  },
+  {
+    range: { min: "24.09.3", max: null },
+    version: "v3",
+  },
+];
+
 const { version } = Astro.params;
 const files = await getArtifactsInRelease(version);
 const release = `https://${S3_REGION}.${S3_ENDPOINT}/${S3_BUCKET}/${version}`;
-
-const oldSignatures = ["ghaf-23.09", "ghaf-23.12", "ghaf-24.03", "ghaf-24.06"];
+const docsVersion = getDocsVersion(docsRules, version.split("-")[1]);
 
 let links = [
   {
@@ -27,21 +43,22 @@ let links = [
     label: "Release tag",
     link: `https://github.com/tiiuae/ghaf/releases/tag/${version}`,
   },
-  {
-    emoji: "✅",
-    label: "Signature verification instructions",
-    link: oldSignatures.includes(version)
-      ? "/signature-verification-themisto"
-      : "/signature-verification",
-  },
 ];
 
-if (oldSignatures.includes(version)) {
+if (docsVersion !== null) {
   links.push({
-    emoji: "🔑",
-    label: "themisto.pub",
-    link: "/keys/themisto.pub",
+    emoji: "✅",
+    label: "Signature verification instructions",
+    link: `/signature-verification/${docsVersion}`,
   });
+
+  if (docsVersion === "v1") {
+    links.push({
+      emoji: "🔑",
+      label: "themisto.pub",
+      link: "/keys/themisto.pub",
+    });
+  }
 }
 ---
 

--- a/src/pages/signature-verification/v1.md
+++ b/src/pages/signature-verification/v1.md
@@ -1,8 +1,8 @@
 ---
-layout: ../layouts/Document.astro
+layout: ../../layouts/Document.astro
 title: Ghaf Signature Verification (themisto)
 ---
-## Signature verification step-by-step instructions with signing key
+## Signature verification instructions for Ghaf 23.09 - 24.06
 
 1. Download the target artifact you want from the release page (here represented as `archive.tar`)
 2. Navigate to where the tar file is.

--- a/src/pages/signature-verification/v2.md
+++ b/src/pages/signature-verification/v2.md
@@ -1,0 +1,42 @@
+---
+layout: ../../layouts/Document.astro
+title: Ghaf Signature Verification
+---
+## Signature verification instructions for Ghaf 24.09 - 24.09.2
+
+1. Download the target artifact you want from the release page (here represented as `archive.tar`)
+2. Navigate to where the tar file is.
+3. Extract the archive into a folder and enter it:
+
+```sh
+tar -xf archive.tar
+cd archive
+```
+
+4. Locate the image file and its signature. Note that for some targets they are located in `sd-image` directory.
+
+5. Run the verification script with the path of the image and signature:
+
+```sh
+nix run github:tiiuae/ci-yubi/bdb2dbf#verify -- \
+    --path disk1.raw.zst \
+    --sigfile disk1.raw.zst.sig  
+```
+
+6. You should see the following message upon successful signature verification:
+
+```
+Signature verification result: {'message': 'Signature Verification Result', 'is_valid': True}
+```
+
+7. The same instructions apply for the provenance file as well, located in the `scs` directory.
+
+```sh
+nix run github:tiiuae/ci-yubi/bdb2dbf#verify -- \
+    --path scs/provenance.json \
+    --sigfile scs/provenance.json.sig
+```
+
+```
+Signature verification result: {'message': 'Signature Verification Result', 'is_valid': True}
+```

--- a/src/pages/signature-verification/v3.md
+++ b/src/pages/signature-verification/v3.md
@@ -1,8 +1,8 @@
 ---
-layout: ../layouts/Document.astro
+layout: ../../layouts/Document.astro
 title: Ghaf Signature Verification
 ---
-## Signature verification step-by-step instructions
+## Signature verification instructions for Ghaf 24.09.3 ->
 
 1. Download the target artifact you want from the release page (here represented as `archive.tar`)
 2. Navigate to where the tar file is.
@@ -13,12 +13,12 @@ tar -xf archive.tar
 cd archive
 ```
 
-4. Locate the image file and its signature. Note that sometimes they are located in `sd-image` directory.
+4. Locate the image file and its signature. Note that for some targets they are located in `sd-image` directory.
 
 5. Run the verification script with the path of the image and signature:
 
 ```sh
-nix run github:tiiuae/ci-yubi#verify -- \
+nix run github:tiiuae/ci-yubi/bdb2dbf#verify -- \
     --cert INT-Ghaf-Devenv-Image \
     --path disk1.raw.zst \
     --sigfile disk1.raw.zst.sig  
@@ -30,11 +30,11 @@ nix run github:tiiuae/ci-yubi#verify -- \
 Signature verification result: {'message': 'Signature Verification Result', 'is_valid': True}
 ```
 
-7. The same instructions apply for the provenance file as well, located in the `scs` directory:
+7. The same instructions apply for the provenance file as well, located in the `scs` directory. Note that the cert name is different.
 
 ```sh
-nix run github:tiiuae/ci-yubi#verify -- \
-    --cert INT-Ghaf-Devenv-Image \
+nix run github:tiiuae/ci-yubi/bdb2dbf#verify -- \
+    --cert INT-Ghaf-Devenv-Provenance \
     --path scs/provenance.json \
     --sigfile scs/provenance.json.sig
 ```


### PR DESCRIPTION
Maps a ghaf version to the corresponding signature verification instructions. A custom comparator is required since the ghaf versions do not conform to semver. The instructions are also now fixed.