### PR TITLE
Serve gala packages under /gala

### DIFF
--- a/src/layouts/Files.astro
+++ b/src/layouts/Files.astro
@@ -10,7 +10,9 @@ const { title } = Astro.props;
 
 <Base title={title}>
   <div class="w-3xl m-auto">
-    <h1 class="text-3xl my-6">Ghaf Archive</h1>
+    <a class="text-white no-underline hover:underline" href="/"
+      ><h1 class="text-3xl my-6">Ghaf Archive</h1></a
+    >
     <slot />
   </div>
 </Base>

--- a/src/lib/artifacts.ts
+++ b/src/lib/artifacts.ts
@@ -22,11 +22,9 @@ export async function getGhafReleases(): Promise<string[]> {
   return folders.filter(Boolean) as string[];
 }
 
-export async function getArtifactsInRelease(version: string): Promise<string[]> {
-  const prefix = `${version}/`;
-
+export async function getArtifactsInBucket(bucket: string, prefix: string): Promise<string[]> {
   const command = new ListObjectsV2Command({
-    Bucket: S3_BUCKET,
+    Bucket: bucket,
     Prefix: prefix,
   });
 

--- a/src/pages/[version]/index.astro
+++ b/src/pages/[version]/index.astro
@@ -1,6 +1,6 @@
 ---
 import Files from "../../layouts/Files.astro";
-import { getGhafReleases, getArtifactsInRelease } from "../../lib/artifacts";
+import { getGhafReleases, getArtifactsInBucket } from "../../lib/artifacts";
 import { S3_BUCKET, S3_ENDPOINT, S3_REGION } from "../../lib/constants";
 import { getDocsVersion } from "../../lib/calver";
 import type { Rule } from "../../lib/calver";
@@ -28,7 +28,8 @@ const docsRules: Rule[] = [
 ];
 
 const { version } = Astro.params;
-const files = await getArtifactsInRelease(version);
+const prefix = version + "/";
+const files = await getArtifactsInBucket(S3_BUCKET, prefix);
 const release = `https://${S3_REGION}.${S3_ENDPOINT}/${S3_BUCKET}/${version}`;
 const docsVersion = getDocsVersion(docsRules, version.split("-")[1]);
 

--- a/src/pages/gala/index.astro
+++ b/src/pages/gala/index.astro
@@ -1,0 +1,23 @@
+---
+import Files from "../../layouts/Files.astro";
+import { getArtifactsInBucket } from "../../lib/artifacts";
+import { S3_ENDPOINT, S3_REGION } from "../../lib/constants";
+
+const files = await getArtifactsInBucket("gala", "");
+const storagePath = `https://${S3_REGION}.${S3_ENDPOINT}/gala`;
+---
+
+<Files title="Gala Packages">
+  <div class="border-solid border-2 rounded-md p-4">
+    <h2>Gala packages</h2>
+    <ul>
+      {
+        files.map((file) => (
+          <li>
+            <a href={`${storagePath}/${file}`}>{file}</a>
+          </li>
+        ))
+      }
+    </ul>
+  </div>
+</Files>


### PR DESCRIPTION
- New url for gala packages is archive.vedenemo.dev/gala/foo.zip
- Old url's can redirect here to keep it working
- Also possible to view the bucket's contents under /gala