### PR TITLE
Remove generic x86 target from checks

### DIFF
--- a/scripts/check-all-targets.sh
+++ b/scripts/check-all-targets.sh
@@ -36,7 +36,6 @@ BASE_URL="$1"
 subdirectories=(
     "aarch64-linux.nvidia-jetson-orin-agx-debug/"
     "aarch64-linux.nvidia-jetson-orin-nx-debug/"
-    "x86_64-linux.generic-x86_64-debug/"
     "x86_64-linux.lenovo-x1-carbon-gen11-debug/"
     "x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64/"
     "x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64/"


### PR DESCRIPTION
Generic x86 target has been removed from release builds. There is no point in checking if the binary image and other files exist.