### PR TITLE
Support artifacts from hetzci

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
             nodejs
             nodePackages.prettier
             minio-client
+            openssl
           ];
         };
       }

--- a/public/keys/GhafInfraSignECP256.pub
+++ b/public/keys/GhafInfraSignECP256.pub
@@ -1,0 +1,4 @@
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1+ghg8Elobsx0jfHoGWxsxyHgI9/
+nP1/6f+enURdIHBq1LOf2ygJShUn2MZimuBxjcbRVhBve1Bj6f0ULm8SeA==
+-----END PUBLIC KEY-----

--- a/public/keys/GhafInfraSignProv.pub
+++ b/public/keys/GhafInfraSignProv.pub
@@ -1,0 +1,3 @@
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAFgPVn2T8wSXjrGha1fD/mkzyUKutFXVIapgpsnxjaVc=
+-----END PUBLIC KEY-----

--- a/scripts/check-all-targets.sh
+++ b/scripts/check-all-targets.sh
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 
-# Color 
+# Color
 RED='\e[31m'
 RESET='\e[0m'
 
@@ -34,21 +34,20 @@ BASE_URL="$1"
 [[ "$BASE_URL" != */ ]] && BASE_URL="${BASE_URL}/"
 
 subdirectories=(
-    "aarch64-linux.nvidia-jetson-orin-agx-debug/"
-    "aarch64-linux.nvidia-jetson-orin-nx-debug/"
-    "x86_64-linux.lenovo-x1-carbon-gen11-debug/"
-    "x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64/"
-    "x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64/"
-    "x86_64-linux.system76-darp11-b-debug/"
+    "packages.aarch64-linux.nvidia-jetson-orin-agx-debug"
+    "packages.aarch64-linux.nvidia-jetson-orin-nx-debug"
+    "packages.x86_64-linux.lenovo-x1-carbon-gen11-debug"
+    "packages.x86_64-linux.nvidia-jetson-orin-agx-debug-from-x86_64"
+    "packages.x86_64-linux.nvidia-jetson-orin-nx-debug-from-x86_64"
+    "packages.x86_64-linux.system76-darp11-b-debug"
 )
 
 main() {
     for subdir in "${subdirectories[@]}"; do
-        local full_url="${BASE_URL}${subdir}"
 	echo
 	echo "* Target: ${subdir}"
         sleep 2
-	bash ./check-one-target.sh ${full_url}
+	bash ./check-one-target.sh "$BASE_URL" "$subdir"
     done
 }
 

--- a/scripts/download-artifacts.sh
+++ b/scripts/download-artifacts.sh
@@ -31,7 +31,7 @@ usage() {
 	echo ""
 	echo "Example:"
 	echo ""
-	echo "  ./$MYNAME -u https://ghaf-jenkins-controller-dev.azure.com/path/to/artifact/"
+	echo "  ./$MYNAME -u https://ci-release.vedenemo.dev/artifacts/path/to/artifact/"
 	echo ""
 }
 
@@ -142,7 +142,6 @@ main() {
 		set -x
 	fi
 	exit_unless_command_exists wget
-	exit_unless_command_exists tar
 	exit_unless_valid_url "$URL"
 	echo "Downloading files to $OUTDIR/artifacts"
 	get_recursively "$URL" "$OUTDIR"

--- a/scripts/verify-signatures.sh
+++ b/scripts/verify-signatures.sh
@@ -1,17 +1,28 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -e          # exit immediately if a command fails
+set -u          # treat unset variables as an error and exit
+set -o pipefail # exit if any pipeline command fails
+
+KEYSDIR=$(realpath "$(dirname "$0")/../public/keys")
+
 verify_image() {
 	echo "Verifying image signature..."
-	nix run github:tiiuae/ci-yubi/bdb2dbf#verify -- \
-		--cert INT-Ghaf-Devenv-Image \
-		--path "$1" \
-		--sigfile "$2"
+	trg="$1"
+	sig="$2"
+	openssl dgst -verify \
+		"$KEYSDIR/GhafInfraSignECP256.pub" -signature "$sig" "$trg"
 }
 
 verify_provenance() {
 	echo "Verifying provenance signature..."
-	nix run github:tiiuae/ci-yubi/bdb2dbf#verify -- \
-		--cert INT-Ghaf-Devenv-Provenance \
-		--path "$1" \
-		--sigfile "$2"
+	trg="$1"
+	sig="$2"
+	openssl pkeyutl -verify -inkey \
+		"$KEYSDIR/GhafInfraSignProv.pub" -pubin -sigfile "$sig" -in "$trg" -rawin
 }
 
 BUILD_DIR="$1"


### PR DESCRIPTION
Modify `scripts/*` to make them support release artifacts produced by https://ci-release.vedenemo.dev, including the verification steps following the manual instructions from https://github.com/tiiuae/ghaf-archive/pull/6.

After this change, the scripts no longer support releases from https://ghaf-jenkins-controller-release.northeurope.cloudapp.azure.com/. Therefore, I also setup a separate branch '[`azure`](https://github.com/tiiuae/ghaf-archive/tree/azure)' in this repository to keep supporting the earlier release artifacts, in case we still need to make releases using the azure-based release environment.