### PR TITLE
Fix tarball names

### DIFF
--- a/scripts/download-artifacts.sh
+++ b/scripts/download-artifacts.sh
@@ -111,7 +111,6 @@ get_recursively() {
 		--level=inf \
 		--timestamping \
 		--no-if-modified-since \
-		--continue \
 		--execute robots=off \
 		--reject 'index.html?*' \
 		--user-agent=Mozilla/5.0 \

--- a/scripts/make-release-build.sh
+++ b/scripts/make-release-build.sh
@@ -125,8 +125,9 @@ create_tarballs() {
 	mkdir -p "/tmp/$GHAF_VERSION"
 	for dir in "$ARTIFACTS_LOCATION"/*/; do
 		target_reldir="$(basename "$dir")"
-		tar -c -f "/tmp/$GHAF_VERSION/$target_reldir.tar" -C "$ARTIFACTS_LOCATION" "$target_reldir"
-		echo " --> created /tmp/$GHAF_VERSION/$target_reldir.tar"
+		tarball=${target_reldir#"packages."} # strip possible 'packages.' prefix
+		tar -c -f "/tmp/$GHAF_VERSION/$tarball.tar" -C "$ARTIFACTS_LOCATION" "$target_reldir"
+		echo " --> created /tmp/$GHAF_VERSION/$tarball.tar"
 	done
 }
 


### PR DESCRIPTION
- Strip '`packages.`' prefix from the tarball names
- Remove wget '`--continue`' option for the same reasons as in: https://github.com/tiiuae/ghaf-infra/pull/745