### PR TITLE
More detailed file location instructions

### DIFF
--- a/src/pages/signature-verification/v4.md
+++ b/src/pages/signature-verification/v4.md
@@ -16,8 +16,9 @@ tar -xf archive.tar
 cd archive
 ```
 
-5. Locate the image file and its signature. Note that for some targets they are
-   located in `sd-image/` directory.
+5. Locate the image file. Note that for some targets it is located in `sd-image/`
+   or `build/` directory. The signature file is in `scs/` or `scs/sd-image/`
+   or `scs/iso/` directory.
 
 6. Run the following `openssl` command with the correct paths of the public key,
    signature and image:
@@ -36,7 +37,8 @@ Verified OK
 ```
 
 8. The provenance file is verified with a different `openssl` command. Note that
-   the public key used is also different.
+   the public key used is also different. The provenance and signature files are
+   located in `scs/` directory.
 
 ```sh
 openssl pkeyutl -verify \


### PR DESCRIPTION
Instructions for finding signature files were partially misleading (target binaries) or missing (provenance).