### PR TITLE
Add secureboot and new verification instructions

### DIFF
--- a/src/pages/[version]/index.astro
+++ b/src/pages/[version]/index.astro
@@ -28,8 +28,19 @@ const docsRules: Rule[] = [
     return: "v3",
   },
   {
-    range: { min: "25.12.1", max: null },
+    range: { min: "25.12.1", max: "26.01.1" },
     return: "v4",
+  },
+  {
+    range: { min: "26.02.1", max: null },
+    return: "v5",
+  },
+];
+
+const securebootDocsRules: Rule[] = [
+  {
+    range: { min: "26.02.1", max: null },
+    return: "v1",
   },
 ];
 
@@ -48,6 +59,7 @@ const files = await getArtifactsInRelease(version);
 const release = `https://${S3_REGION}.${S3_ENDPOINT}/${S3_BUCKET}/${version}`;
 const docsVersion = parseRules(docsRules, version.split("-")[1]);
 const flashingScript = parseRules(flashScriptLocations, version.split("-")[1]);
+const securebootDocs = parseRules(securebootDocsRules, version.split("-")[1]);
 
 const prettyVersion = "Ghaf " + version.split("-")[1];
 
@@ -75,12 +87,21 @@ let links = [
     label: "Signature verification instructions",
     link: `/signature-verification/${docsVersion}`,
   },
-  {
-    emoji: "📜",
-    label: "flash.sh",
-    link: flashingScript,
-  },
 ];
+
+if (securebootDocs) {
+  links.push({
+    emoji: "📄",
+    label: "Secure boot instructions",
+    link: `/secure-boot/${securebootDocs}`,
+  });
+}
+
+links.push({
+  emoji: "📜",
+  label: "flash.sh",
+  link: flashingScript,
+});
 
 if (docsVersion === "v1") {
   links.push({

--- a/src/pages/secure-boot/v1.md
+++ b/src/pages/secure-boot/v1.md
@@ -1,0 +1,19 @@
+---
+layout: ../../layouts/Document.astro
+title: Ghaf Secure Boot
+---
+
+## Secure boot instructions for Ghaf 26.02.1 ->
+
+Ghaf provides images with a signed UEFI, which means they can be booted with
+secure boot turned on. The key material for enrollment can be found in
+[ghaf-infra-pki](https://github.com/tiiuae/ghaf-infra-pki) repo.
+
+Required steps vary between UEFI implementations, but generally you should turn
+on secure boot, and get it into setup mode.
+
+To enroll the keys into your machine, run the enrollment script:
+
+```sh
+nix run github:tiiuae/ghaf-infra-pki/213842#enroll-secureboot-keys
+```

--- a/src/pages/signature-verification/v4.md
+++ b/src/pages/signature-verification/v4.md
@@ -5,7 +5,7 @@ title: Ghaf Signature Verification
 
 # Signature verification instructions
 
-## Ghaf 25.12.1 ->
+## Ghaf 25.12.1 -> 26.01.1
 
 ---
 

--- a/src/pages/signature-verification/v5.md
+++ b/src/pages/signature-verification/v5.md
@@ -1,0 +1,53 @@
+---
+layout: ../../layouts/Document.astro
+title: Ghaf Signature Verification
+---
+
+## Signature verification instructions
+
+## Ghaf 26.02.1 ->
+
+---
+
+1. Download the target artifact you want from the release page (here represented
+   as `archive.tar`)
+2. Navigate to where the tar file is.
+3. Extract the archive into a folder and enter it:
+
+```sh
+tar -xf archive.tar
+cd archive
+```
+
+4. Locate the image file. Note that for some targets it is located in
+   `sd-image/` or `build/` directory. The signature file is in `scs/` or
+   `scs/sd-image/` or `scs/iso/` directory.
+
+5. Run the verification script from
+   [ghaf-infra](https://github.com/tiiuae/ghaf-infra). This script will use the
+   correct public keys, which are stored in and pulled from
+   [ghaf-infra-pki](https://github.com/tiiuae/ghaf-infra-pki).
+
+```sh
+nix run github:tiiuae/ghaf-infra/669e944#verify-signature -- \
+    image disk1.raw.zst disk1.raw.zst.sig
+```
+
+6. You should see the following message upon successful signature verification:
+
+```
+Verified OK
+```
+
+7. The provenance file is verified with the same script but using the
+   `provenance` mode. The provenance and signature files are located in `scs/`
+   directory.
+
+```sh
+nix run github:tiiuae/ghaf-infra/669e944#verify-signature -- \
+    provenance provenance.json provenance.json.sig
+```
+
+```
+Signature Verified Successfully
+```


### PR DESCRIPTION
- Secureboot instructions v1
- Signature verification instructions v5
  - Use `verify-signature` from ghaf-infra
  - Don't publish public keys anymore