### PR TITLE
Update nodejs to v25

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           # should match the node version we have in the flake devshell
-          node-version: 22
+          node-version: 25
 
       - name: Install dependencies
         run: npm ci --include=dev

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
       {
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [
-            nodejs
+            nodejs_25
             prettier
             minio-client
             openssl


### PR DESCRIPTION
Fixes the failing check which was caused by node 22 on the ci, and 24 on the flake. Now uses version pinned nix package.